### PR TITLE
Disable posframe-mouse-banish on macOS

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -98,7 +98,7 @@
   :group 'lisp
   :prefix "posframe-")
 
-(defcustom posframe-mouse-banish t
+(defcustom posframe-mouse-banish (not (eq system-type 'darwin))
   "Mouse will be moved to (0 , 0) when it is non-nil."
   :group 'posframe
   :type 'boolean)


### PR DESCRIPTION
There's no need for the hack on macOS, so it makes sense to disable it by default.