### PR TITLE
use empty posframe title for window manager

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -189,6 +189,7 @@ This posframe's buffer is POSFRAME-BUFFER."
                     face-remap)))
     (with-current-buffer posframe-buffer
       ;; Many variables take effect after call `set-window-buffer'
+      (setq-local frame-title-format "")
       (setq-local left-fringe-width nil)
       (setq-local right-fringe-width nil)
       (setq-local fringes-outside-margins 0)


### PR DESCRIPTION
For macOS window manager chunkwm, it uses title to avoid tiling tooltip, thought
posframe should work the same way.