### PR TITLE
* posframe.el (posframe--insert-string): refactoring

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -547,15 +547,12 @@ https://github.com/tumashu/posframe/issues/4#issuecomment-357514918"
 If NO-PROPERTIES is non-nil, all properties of STRING
 will be removed."
   (when (and string (stringp string))
-    (remove-text-properties
-     0 (length string) '(read-only t) string)
-    ;; Does inserting string then deleting the before
-    ;; contents reduce flicking? Maybe :-)
-    (goto-char (point-min))
-    (if no-properties
-        (insert (substring-no-properties string))
-      (insert string))
-    (delete-region (point) (point-max))))
+    (remove-text-properties 0 (length string) '(read-only t) string)
+    (let ((string* (if no-properties
+                       (substring-no-properties string)
+                     string)))
+      (erase-buffer)
+      (insert string*))))
 
 (defun posframe--set-frame-size (posframe height min-height width min-width)
   "Set POSFRAME's size.


### PR DESCRIPTION
Hi! Thank you for developing such a great package!

In relation to commit da93ec72d9b1fb24d244e3d92f0ab35f25c0e943, it seems better to change  posframe--insert-string function in this way.

- before
```elisp
(defun posframe--insert-string (string no-properties)
  "Insert STRING to current buffer.
If NO-PROPERTIES is non-nil, all properties of STRING
will be removed."
  (when (and string (stringp string))
    (remove-text-properties
     0 (length string) '(read-only t) string)
    ;; Does inserting string then deleting the before
    ;; contents reduce flicking? Maybe :-)
    (goto-char (point-min))
    (if no-properties
        (insert (substring-no-properties string))
      (insert string))
    (delete-region (point) (point-max))))
```
- after
```elisp
(defun posframe--insert-string (string no-properties)
  "Insert STRING to current buffer.
If NO-PROPERTIES is non-nil, all properties of STRING
will be removed."
  (when (and string (stringp string))
    (remove-text-properties 0 (length string) '(read-only t) string)
    (let ((string* (if no-properties
                       (substring-no-properties string)
                     string)))
      (erase-buffer)
      (insert string*))))
```
[NOTE]: I haven't signed FSF yet. Please comment when additional work is needed.

---
commit da93ec72d9b1fb24d244e3d92f0ab35f25c0e943 fixes flicking issue.
So, we could remove strange trick from posframe--insert-string.

and remove corresponding comments below
    ;; Does inserting string then deleting the before
    ;; contents reduce flicking? Maybe :-)

Also, it is recommended that we do the necessary processing at the
beginning of the function rather than 'branching the action'
depending on the arguments.