### PR TITLE
Make the buffer in posframe dedicated

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -304,7 +304,8 @@ This posframe's buffer is BUFFER-OR-NAME."
             (set-window-parameter posframe-window 'mode-line-format 'none))
           (unless respect-header-line
             (set-window-parameter posframe-window 'header-line-format 'none))
-          (set-window-buffer posframe-window buffer)))
+          (set-window-buffer posframe-window buffer)
+          (set-window-dedicated-p posframe-window t)))
       posframe--frame)))
 
 (defun posframe-arghandler-default (_buffer-or-name _arg-name value)


### PR DESCRIPTION
- I am trying to use posframe to create a floating control for dap-mode which
will have Step in/Step out/Continue, etc buttons (see screenshot). The problem
that I am facing is that when posframe-show which is called when the new set of
buttons is enabled is performed when current-frame the posframe itself. In order
to solve that in our code I used

``` elisp
(when (eq (selected-frame) pos-frame)
  (select-frame (frame-parent pos-frame)))
```

But when I do that from time to time the buffer in the posframe chamges. The
following piece of code fixes the issue.

![Screenshot](https://user-images.githubusercontent.com/13259670/65455466-f4104380-de4f-11e9-96bf-e02b81c5eb7c.png)
