### PR TITLE
prevent posframes from getting keyboard input

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -595,6 +595,22 @@ You can use `posframe-delete-all' to delete all posframes."
             (cons position height))
       height)))
 
+(defvar posframe--previous-frame nil)
+
+(defun posframe--redirect-posframe-focus ()
+  "Redirect focus from the posframe to the previous frame. This prevents the
+posframe from catching keyboard input if the window manager selects it."
+  (interactive)
+  (if (eq (selected-frame) posframe--frame)
+      (when posframe--previous-frame
+        (redirect-frame-focus posframe--frame posframe--previous-frame))
+    (progn
+      (setf posframe--previous-frame (selected-frame))
+      (when posframe--frame
+        (redirect-frame-focus posframe--frame posframe--previous-frame)))))
+
+(add-hook 'focus-in-hook #'posframe--redirect-posframe-focus)
+
 (defun posframe--mouse-banish (frame)
   "Banish mouse to the (0 . 0) of FRAME.
 FIXME: This is a hacky fix for the mouse focus problem, which like:


### PR DESCRIPTION
This PR makes posframe automatically redirect input focus back to the previous frame when the posframe gets focus. This seems to fix the issue where the posframe erroneously grabs the keyboard input when it appears under the mouse cursor in some window managers.

This should make the option `posframe-mouse-banish` unnecessary, however I didn't remove it in this PR in case some people would still want it. If you think I should remove that option, just let me know.

I also wrote [a comment](https://github.com/tumashu/posframe/issues/27#issuecomment-554693252) on issue #27 about this solution as well.