### PR TITLE
posframe.el (posframe--redirect-posframe-focus): simplify

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -595,10 +595,8 @@ You can use `posframe-delete-all' to delete all posframes."
             (cons position height))
       height)))
 
-(defvar posframe--previous-frame nil)
-
 (defun posframe--redirect-posframe-focus ()
-  "Redirect focus from the posframe to the previous frame. This prevents the
+  "Redirect focus from the posframe to the parent frame. This prevents the
 posframe from catching keyboard input if the window manager selects it."
   (when (eq (selected-frame) posframe--frame)
     (redirect-frame-focus posframe--frame (frame-parent))))

--- a/posframe.el
+++ b/posframe.el
@@ -600,14 +600,8 @@ You can use `posframe-delete-all' to delete all posframes."
 (defun posframe--redirect-posframe-focus ()
   "Redirect focus from the posframe to the previous frame. This prevents the
 posframe from catching keyboard input if the window manager selects it."
-  (interactive)
-  (if (eq (selected-frame) posframe--frame)
-      (when posframe--previous-frame
-        (redirect-frame-focus posframe--frame posframe--previous-frame))
-    (progn
-      (setf posframe--previous-frame (selected-frame))
-      (when posframe--frame
-        (redirect-frame-focus posframe--frame posframe--previous-frame)))))
+  (when (eq (selected-frame) posframe--frame)
+    (redirect-frame-focus posframe--frame (frame-parent))))
 
 (add-hook 'focus-in-hook #'posframe--redirect-posframe-focus)
 


### PR DESCRIPTION
This is to simplify the `posframe--redirect-posframe-focus` function code.

Actually, for me, this is not only for code simplification because I found a very tricky case that this function doesn't work properly on Xmonad WM.

In short, on Xmoand, run Emacs, move to the other workspace, come back to Emacs, put cursor where posframe would pop up, and do run posframe command. Then `(eq (selected-frame) (posframe))` is true but `posframe--previous-frame` is still `nil`, therefore focus redirection does not happen.

I tested this on Gnome DE, Awesome WM and Xmonad and this weird thing happened only on Xmonad. So, this might be a case by a bug of Xmoand. 

So, you may value this pull request just in term of code simplification and consider to merge or not. 

Thank you.