### PR TITLE
Fix incorrect posframe size after posframe-refresh

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -636,15 +636,12 @@ will be removed."
   "Set POSFRAME's size.
 It will set the size by the POSFRAME's HEIGHT, MIN-HEIGHT
 WIDTH and MIN-WIDTH."
-  (if (and width height)
-      (unless (equal posframe--last-posframe-size
-                     (list height min-height width min-width))
-        (fit-frame-to-buffer
-         posframe height min-height width min-width)
-        (setq-local posframe--last-posframe-size
-                    (list height min-height width min-width)))
+  (unless (equal posframe--last-posframe-size
+                 (list height min-height width min-width))
     (fit-frame-to-buffer
-     posframe height min-height width min-width)))
+     posframe height min-height width min-width)
+    (setq-local posframe--last-posframe-size
+                (list height min-height width min-width))))
 
 (defun posframe--set-frame-position (posframe position
                                               parent-frame-width


### PR DESCRIPTION
Current `posframe-refresh` call `fit-frame-to-buffer` with no min-height, min-width args when posframe's `posframe--last-posframe-size` is nil.

This cause incorrent posframe size after `posframe-refresh`.

sample code:
```elisp
(defvar buf " *test*")
(posframe-show buf :background-color "red")
(with-current-buffer buf
  (erase-buffer)
  (insert "ffffffffffffff")
  (posframe-refresh buf))
```
screenshot:
<img width="587" alt="スクリーンショット 2020-03-04 12 10 15" src="https://user-images.githubusercontent.com/13937915/75841470-25366c00-5e11-11ea-97ec-1d1b64ef40a2.png">


This PR set `posframe--last-posframe-size` even when width or height is nil.

I think this is not NS-specific problem.