### PR TITLE
Add a package that uses posframe

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -142,6 +142,7 @@
 ;; 4. [[https://github.com/tumashu/ivy-posframe][ivy-posframe]]
 ;; 5. [[https://github.com/tumashu/company-posframe][company-posframe]]
 ;; 6. [[https://github.com/randomwangran/org-marginalia-posframe][org-marginalia-posframe]]
+;; 7. ...
 
 ;;; Code:
 ;; * posframe's code                         :CODE:

--- a/posframe.el
+++ b/posframe.el
@@ -141,7 +141,7 @@
 ;; 3. [[https://github.com/tumashu/pyim][pyim]]
 ;; 4. [[https://github.com/tumashu/ivy-posframe][ivy-posframe]]
 ;; 5. [[https://github.com/tumashu/company-posframe][company-posframe]]
-;; 6. ...
+;; 6. [[https://github.com/randomwangran/org-marginalia-posframe][org-marginalia-posframe]]
 
 ;;; Code:
 ;; * posframe's code                         :CODE:


### PR DESCRIPTION
Dear mainterainers:

Thanks for creating `posframe`. I use it as my daily driver.

I write small functions that use `posframe` to show the @nobiot 's new package [org-marginalia](https://github.com/nobiot/org-marginalia).

As an inexperienced elisp player, there must be a more elegant solution. Suggestions are welcome.

Thank you.