### PR TITLE
Fix frame fit when there are leading or trailing spaces

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -720,8 +720,8 @@ will be removed."
 (defun posframe--fit-frame-to-buffer (posframe height min-height width min-width)
   ;; This only has effect if the user set the latter var to `hide'.
   (let ((x-gtk-resize-child-frames posframe-gtk-resize-child-frames))
-    (fit-frame-to-buffer
-     posframe height min-height width min-width)))
+    (fit-frame-to-buffer-1
+     posframe height min-height width min-width nil nil nil)))
 
 (defun posframe--set-frame-size (posframe height min-height width min-width)
   "Set POSFRAME's size.


### PR DESCRIPTION
See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=45748

The bug impacts company-posframe when displaying a single result by truncating the last line. It also makes company-posframe truncate the last padding space when displaying multiple results.

This will have the effect of resizing the frame to include leading and trailing newlines as well, which is probably the desired behavior anyway so there's no need to scroll.