### PR TITLE
Silence byte-compiler

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -796,7 +796,8 @@ posframe from catching keyboard input if the window manager selects it."
     (redirect-frame-focus posframe--frame (frame-parent))))
 
 (if (version< emacs-version "27.1")
-    (add-hook 'focus-in-hook #'posframe--redirect-posframe-focus)
+    (with-no-warnings
+      (add-hook 'focus-in-hook #'posframe--redirect-posframe-focus))
   (add-function :after after-focus-change-function #'posframe--redirect-posframe-focus))
 
 (defun posframe--mouse-banish (parent-frame &optional posframe)


### PR DESCRIPTION
We only use `posframe--redirect-posframe-focus` for Emacs versions
before 27.1, so don't warn about that being obsolete when using that
or a later version; we know.