### PR TITLE
Check non-nullity of the buffer

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -1003,7 +1003,8 @@ posframe is very very slowly, `posframe-hide' is more useful."
   "Delete posframe pertaining to BUFFER-OR-NAME.
 BUFFER-OR-NAME can be a buffer or a buffer name."
   (let* ((buffer (get-buffer buffer-or-name))
-         (posframe (posframe--find-existing-posframe buffer))
+         (posframe (when buffer
+                     (posframe--find-existing-posframe buffer)))
          ;; NOTE: `delete-frame' runs ‘delete-frame-functions’ before
          ;; actually deleting the frame, unless the frame is a
          ;; tooltip, posframe is a child-frame, but its function like


### PR DESCRIPTION
Hello, I am using `posframe.el` in [mozc-posframe](https://github.com/akirak/mozc-posframe).

A recent change (62ca653b7256b6ad88cd7768d370eea483931168) seems to have caused a new bug (https://github.com/akirak/mozc-posframe/issues/6):

> posframe-delete-frame: Attempt to delete the sole visible or iconified frame

I think this PR will fix the issue. Could you review this PR? Thank you for developing this package.