### PR TITLE
configure posframe position during creation if position is available

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -409,6 +409,7 @@ You can use `posframe-delete-all' to delete all posframes."
       (setq posframe
             (posframe--create-posframe
              buffer
+             :position position
              :font font
              :parent-frame
              (unless ref-position
@@ -541,6 +542,7 @@ You can use `posframe-delete-all' to delete all posframes."
 
 (cl-defun posframe--create-posframe (buffer-or-name
                                      &key
+                                     position
                                      parent-frame
                                      foreground-color
                                      background-color
@@ -666,6 +668,8 @@ ACCEPT-FOCUS."
                        (visibility . nil)
                        (cursor-type . nil)
                        (minibuffer . nil)
+                       (left . ,(if (consp position) (car position) 0))
+                       (top . ,(if (consp position) (cdr position) 0))
                        (width . 1)
                        (height . 1)
                        (no-special-glyphs . t)


### PR DESCRIPTION
Hi,

I'm using Emacs for MacOS (https://emacsformacosx.com), and when running Helm posframe, Emacs always flickers when showing the posframe. 

The reason is that the posframe frame is first created at location `(0, 0)`, and it is supposed to be invisible, and will be moved to the desired position later. However, in Emacs for MacOS, somehow the posframe was visible before it is moved to the new location, which causes the flickering.

In this PR, I fixed this issue by supplying the position information (if it is available in the form of `(left . top)`), so that the posframe is created at the desired location when `position` is supplied.

Can you review this PR and merge it if possible?

Thanks!

