### PR TITLE
Check if given BUFFER-OR-NAME is non-nil in posframe-hide

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -1037,12 +1037,13 @@ BUFFER-OR-NAME can be a buffer or a buffer name."
   ;; called, otherwise:
   ;;   (add-hook 'buffer-list-update-hook  #'posframe-hide)
   ;; will lead to infinite recursion.
-  (let ((buffer-list-update-hook nil))
-    (dolist (frame (frame-list))
-      (let ((buffer-info (frame-parameter frame 'posframe-buffer)))
-        (when (or (equal buffer-or-name (car buffer-info))
-                  (equal buffer-or-name (cdr buffer-info)))
-          (posframe--make-frame-invisible frame))))))
+  (when buffer-or-name
+    (let ((buffer-list-update-hook nil))
+      (dolist (frame (frame-list))
+        (let ((buffer-info (frame-parameter frame 'posframe-buffer)))
+          (when (or (equal buffer-or-name (car buffer-info))
+                    (equal buffer-or-name (cdr buffer-info)))
+            (posframe--make-frame-invisible frame)))))))
 
 (defun posframe-hidehandler-daemon ()
   "Run posframe hidehandler daemon."


### PR DESCRIPTION
posframe-hide should not attempt to make non-posframe frames invisible.

Debugger entered--Lisp error: (error "Attempt to make invisible the sole visible or icon...")
  posframe--make-frame-invisible(#<frame *scratch* 0x1489bb230>)
  posframe-hide(nil)
  vertico-posframe-mode(0)
  ...

(posframe-hide nil) can attempt to hide *scratch* buffer's frame accidentally.
vertico-posframe also has an issue though.

```
#+begin_example
Debugger entered--Lisp error: (error "Attempt to make invisible the sole visible or icon...")
  posframe--make-frame-invisible(#<frame *scratch* 0x1489bb230>)
  posframe-hide(nil)
  vertico-posframe-mode(0)
  (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))()
  apply((closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0))) nil)
  #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0))))()
  apply(#f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) nil)
  #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) doom-modeline-focus-change)()
  apply(#f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) doom-modeline-focus-change) nil)
  #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) doom-modeline-focus-change) #f(compiled-function () #<bytecode 0x12cd0f46279daf62>))()
  apply(#f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) doom-modeline-focus-change) #f(compiled-function () #<bytecode 0x12cd0f46279daf62>)) nil)
  #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) doom-modeline-focus-change) #f(compiled-function () #<bytecode 0x12cd0f46279daf62>)) doom-modeline-update-buffer-file-name)()
  apply(#f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if ... 1 0)))) doom-modeline-focus-change) #f(compiled-function () #<bytecode 0x12cd0f46279daf62>)) doom-modeline-update-buffer-file-name) nil)
  #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after #f(advice-wrapper :after ignore blink-cursor--rescan-frames) posframe--redirect-posframe-focus) (closure (bootstrap-version t) nil (vertico-posframe-mode (if (my/posframe-after-focus-change-p) 1 0)))) doom-modeline-focus-change) #f(compiled-function () #<bytecode 0x12cd0f46279daf62>)) doom-modeline-update-buffer-file-name) (closure (bootstrap-version t) nil (if (frame-focus-state) nil (garbage-collect))))()
  handle-focus-out((focus-out #<frame *scratch* 0x1489bb230>))
  funcall-interactively(handle-focus-out (focus-out #<frame *scratch* 0x1489bb230>))
  command-execute(handle-focus-out nil [(focus-out #<frame *scratch* 0x1489bb230>)] t)
#+end_example
```
