### PR TITLE
store window start, end position into last position info

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -480,6 +480,8 @@ You can use `posframe-delete-all' to delete all posframes."
                        :parent-window-left parent-window-left
                        :parent-window-width parent-window-width
                        :parent-window-height parent-window-height
+                       :window-start (window-start)
+                       :window-end (window-end)
                        :mouse-x (car mouse-position)
                        :mouse-y (cdr mouse-position)
                        :mode-line-height mode-line-height


### PR DESCRIPTION
Hi,

Currently, I notice that `posframe` does not update the posframe position corresponding to the current point if I run `recenter-top-bottom` on the target buffer.

This issue happened in <https://github.com/alexmurray/flycheck-posframe>

So, I created this PR to update the `window-start` and `window-end` position to force `posframe` recompute a new position when the `window-start` and `window-end` are changed (for example, by `recenter-top-bottom`).

Can you consider merging this PR?

Thanks!

