### PR TITLE
Use parent's minibuffer window

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -693,7 +693,7 @@ ACCEPT-FOCUS."
                        (undecorated . t)
                        (visibility . nil)
                        (cursor-type . nil)
-                       (minibuffer . nil)
+                       (minibuffer . ,(minibuffer-window parent-frame))
                        (left . ,(if (consp position) (car position) 0))
                        (top . ,(if (consp position) (cdr position) 0))
                        (width . 1)


### PR DESCRIPTION
This is the same behavior with [corfu](https://github.com/minad/corfu/blob/b779552341354d59365a981fd208ae07b7a2950a/corfu.el#L464)