### PR TITLE
Prevent running inside a minibuffer-only frame

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -125,7 +125,8 @@ effect.")
   (and (>= emacs-major-version 26)
        (not (or noninteractive
                 emacs-basic-display
-                (not (display-graphic-p))))))
+                (not (display-graphic-p))
+		(eq (frame-parameter (selected-frame) 'minibuffer) 'only)))))
 
 ;;;###autoload
 (cl-defun posframe-show (buffer-or-name


### PR DESCRIPTION
Same as this [PR](https://github.com/tumashu/vertico-posframe/pull/45).