### PR TITLE
posframe-show: Take mode-line-height into account from minibuffer

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -1286,13 +1286,13 @@ The structure of INFO can be found in docstring of
 (defun posframe-poshandler-frame-top-left-or-right-other-corner (info)
   "Posframe's position handler.
 
-This poshandler function let posframe align to top left or top right corner of frame,
-based on whether current window is relatively at left or right in the current frame.
-If window is at left, place posframe on right, and vice versa.
-(This is calculated by whether current window center is left or right to frame center)
+This poshandler function let posframe align to top left or top right
+corner of frame, based on whether current window is relatively at left
+or right in the current frame.  If window is at left, place posframe on
+right, and vice versa.  (This is calculated by whether current window
+center is left or right to frame center.)
 
-The structure of INFO can be found in docstring of
-`posframe-show'."
+The structure of INFO can be found in docstring of `posframe-show'."
   (let ((window-left (plist-get info :parent-window-left))
         (window-width (plist-get info :parent-window-width))
         (frame-width (plist-get info :parent-frame-width)))

--- a/posframe.el
+++ b/posframe.el
@@ -126,7 +126,7 @@ effect.")
        (not (or noninteractive
                 emacs-basic-display
                 (not (display-graphic-p))
-		(eq (frame-parameter (selected-frame) 'minibuffer) 'only)))))
+                (eq (frame-parameter (selected-frame) 'minibuffer) 'only)))))
 
 ;;;###autoload
 (cl-defun posframe-show (buffer-or-name
@@ -712,7 +712,7 @@ ACCEPT-FOCUS."
          (or font (face-attribute 'default :font parent-frame)))
         (when border-color
           (if parent-frame
-	      (set-face-background
+              (set-face-background
                (if (facep 'child-frame-border)
                    'child-frame-border
                  'internal-border)

--- a/posframe.el
+++ b/posframe.el
@@ -404,7 +404,9 @@ You can use `posframe-delete-all' to delete all posframes."
          (font-width (default-font-width))
          (font-height (with-current-buffer (window-buffer parent-window)
                         (posframe--get-font-height position)))
-         (mode-line-height (window-mode-line-height))
+         (mode-line-height (window-mode-line-height
+                            (and (window-minibuffer-p)
+                                 (ignore-errors (window-in-direction 'above)))))
          (minibuffer-height (window-pixel-height (minibuffer-window)))
          (header-line-height (window-header-line-height parent-window))
          (tab-line-height (if (functionp 'window-tab-line-height)


### PR DESCRIPTION
When the current buffer is a minibuffer, use the height of the mode-line
of the window above it.  Without this the posframe covers the mode-line
when using, e.g., `posframe-poshandler-frame-bottom-right-corner` and
the `posframe-show` is called while the minibuffer is active.

The other two commits clean up whitespace and docstrings.