### PR TITLE
Add ability to adjust posframe text scale based on text scale of parent frame

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -62,12 +62,9 @@ custom function for EXWM users."
   "The function to adjust value of text-scale of posframe buffer.
 
 Accepts single argument which is the value of parent buffer `text-scale-mode-amount'
-or nil if the `text-scale-mode' is disabled in the parent buffer.
-`posframe-text-scale-factor-default' is an alias for `identity' function."
+or nil if the `text-scale-mode' is disabled in the parent buffer."
   :group 'posframe
   :type 'function)
-
-(defalias #'posframe-text-scale-factor-default #'identity)
 
 (defvar-local posframe--frame nil
   "Record posframe's frame.")
@@ -1531,6 +1528,11 @@ window manager selects it."
              ;; See posframe-show's accept-focus argument.
              (not posframe--accept-focus))
     (redirect-frame-focus posframe--frame (frame-parent))))
+
+(defun posframe-text-scale-factor-default (parent-text-scale-mode-amount)
+  "Return PARENT-TEXT-SCALE-MODE-AMOUNT or 0 if it is nil.
+This ensures text scale factor is always a number for posframe display."
+  (or parent-text-scale-mode-amount 0))
 
 (provide 'posframe)
 


### PR DESCRIPTION
*Why*:
Previously posframe always used `text-scale` 0 regardless of user specified text scale on parent frame.
This lead to inconsistent UI and even worse bad user experience affecting accessibility of the editor.

This changes default behaviour of posframe to match text-scale of parent frame with option for user to customise this behaviour using `posframe-text-scale-factor-function` variable.

*Example*:
old
![posframe-text-scale-old](https://github.com/user-attachments/assets/9bb6e054-f8ef-4c27-8c5c-80014ed3db06)
new
![posframe-text-scale-new](https://github.com/user-attachments/assets/58d125a6-3a8a-4054-8928-fcc9a2e1f07a)
new custom
![posframe-text-scale-new-custom](https://github.com/user-attachments/assets/160f2889-b716-48ad-8644-26f3919f4776)
