### PR TITLE
Fix typo `;`

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -212,7 +212,7 @@ position.  Its argument is a plist of the following form:
    :parent-window-width  xxx
    :parent-window-height xxx
    :mouse-x xxx
-   ;mouse-y xxx
+   :mouse-y xxx
    :minibuffer-height xxx
    :mode-line-height  xxx
    :header-line-height xxx


### PR DESCRIPTION
This line appears to be a `:keyword` rather than a `; comment`.

I've recently started using posframe and it's been very helpful [for me](https://github.com/emacs-php/phpstan.el/pull/61). Thank you for your work!
