### PR TITLE
Fix condition in posframe-workable-p

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -136,7 +136,7 @@ effect.")
        (not emacs-basic-display)
        (or (display-graphic-p)
            (featurep 'tty-child-frames))
-       (eq (frame-parameter (selected-frame) 'minibuffer) 't)))
+       (not (eq (frame-parameter (selected-frame) 'minibuffer) 'only))))
 
 ;;;###autoload
 (cl-defun posframe-show (buffer-or-name


### PR DESCRIPTION
In this commit (https://github.com/tumashu/posframe/commit/a31476cbe0df3cfffad7efeda84700a13d7ebc01) support for tty child frames were added and the conditions in `posframe-workable-p` were negated.

The negation of
`(eq (frame-parameter (selected-frame) 'minibuffer) 'only)`
became
`(eq (frame-parameter (selected-frame) 'minibuffer) 't)`

But there are other values of the minibuffer frame parameter that work besides `t`. For example, the frame could have the minibuffer parameter set to a specific window instead of using a local minibuffer.