### PR TITLE
fix: silence byte-compile warnings and add CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  byte-compile:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs_version:
+          - '26.1'
+          - '30.1'
+          - snapshot
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: purcell/setup-emacs@master
+        with:
+          version: ${{ matrix.emacs_version }}
+
+      - name: Byte-compile (warnings as errors)
+        run: |
+          emacs -Q --batch -L . \
+            --eval '(setq byte-compile-error-on-warn t)' \
+            -f batch-byte-compile posframe.el posframe-benchmark.el

--- a/posframe.el
+++ b/posframe.el
@@ -40,6 +40,17 @@
 ;; * posframe's code                         :CODE:
 (require 'cl-lib)
 
+;; `text-scale-mode-amount' is defined in face-remap.el and bound only
+;; while `text-scale-mode' is enabled; the value is read lazily and
+;; guarded by `bound-and-true-p' at the call site.  `tab-line-format' was
+;; introduced in Emacs 27 and is only assigned under a runtime version
+;; check.  Declaring both keeps the byte-compiler from warning about a
+;; reference or assignment to a free variable; a bare `defvar' only marks
+;; the symbol as special and assigns no value, so this is
+;; behaviour-preserving.
+(defvar text-scale-mode-amount)
+(defvar tab-line-format)
+
 (defgroup posframe nil
   "Pop a posframe (just a frame) at point."
   :group 'lisp

--- a/posframe.el
+++ b/posframe.el
@@ -51,6 +51,20 @@
 (defvar text-scale-mode-amount)
 (defvar tab-line-format)
 
+;; C primitives that the byte-compiler may not see: some are absent on a
+;; non-graphical (nox) build, and `set-frame-size-and-position-pixelwise'
+;; and `window-tab-line-height' were added in Emacs 27 so are missing on
+;; the declared 26.1 minimum.  Callers guard each use with `(fboundp ...)',
+;; `(functionp ...)', or a runtime version check.  Declaring them keeps
+;; the byte-compiler quiet without defining or loading anything, so this
+;; is behaviour-preserving.
+(declare-function set-frame-size-and-position-pixelwise "frame.c"
+                  (frame &optional width height left top))
+(declare-function window-tab-line-height "window.c" (&optional window))
+(declare-function font-info "font.c" (name &optional frame))
+(declare-function font-at "font.c" (position &optional window string))
+(declare-function fontp "font.c" (object &optional extra-type))
+
 (defgroup posframe nil
   "Pop a posframe (just a frame) at point."
   :group 'lisp


### PR DESCRIPTION
This is a small maintenance contribution that makes `posframe.el` and
`posframe-benchmark.el` byte-compile cleanly across Emacs 26.1, 30.1, and
snapshot, and adds CI to keep them clean.

All changes are behaviour-preserving.

## Fixes (one commit per warning type)

### Free variable references/assignments
- `text-scale-mode-amount` (referenced in `posframe-show`): defined in
  face-remap.el and only bound while `text-scale-mode` is enabled. The
  call site already guards with `bound-and-true-p`.
- `tab-line-format` (assigned via `setq-local`): introduced in Emacs 27
  and only assigned under a runtime `(version< "27.0" emacs-version)`
  check, so on the declared 26.1 minimum it is never touched at runtime.

Both are declared with a bare `(defvar ...)`, which only marks the
symbol special for the byte-compiler and assigns no value.

### Functions not known to be defined
Declared with `declare-function` (informs the compiler only, defines
and loads nothing):
- `set-frame-size-and-position-pixelwise` (Emacs 27+, guarded by
  `fboundp`)
- `window-tab-line-height` (Emacs 27+, guarded by `functionp`)
- `font-info`, `font-at`, `fontp` (graphical C primitives missing on a
  non-graphical/nox build)

## CI
A new GitHub Actions workflow byte-compiles both files with
`byte-compile-error-on-warn` enabled across a matrix of Emacs 26.1
(the declared minimum), 30.1, and snapshot, so future warnings fail the
build. A dependabot config keeps the action versions current.

The fork CI is green on all three Emacs versions.

## Residual / out of scope
None. After these fixes the package byte-compiles with zero warnings on
26.1, 30.1, and snapshot. No behaviour-changing warnings remained.