### PR TITLE
Silence warning about undefined text-scale-mode-amount

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -421,7 +421,8 @@ You can use `posframe-delete-all' to delete all posframes."
          (font-height (with-current-buffer (window-buffer parent-window)
                         (posframe--get-font-height position)))
          (parent-text-scale-mode-amount (with-current-buffer (window-buffer parent-window)
-                                          (and (bound-and-true-p text-scale-mode) text-scale-mode-amount)))
+                                          (and (bound-and-true-p text-scale-mode)
+                                               (bound-and-true-p text-scale-mode-amount))))
          (mode-line-height (window-mode-line-height
                             (and (window-minibuffer-p)
                                  (ignore-errors (window-in-direction 'above)))))


### PR DESCRIPTION
``` emacs-lisp
$ emacs -Q --batch --funcall batch-byte-compile posframe.el
In posframe-show:
posframe.el:425:48: Warning: reference to free variable ‘text-scale-mode-amount’
$ emacs --version
GNU Emacs 31.0.91
...
```