### PR TITLE
Don't reuse a posframe--frame created on a different terminal

### DIFF
--- a/posframe.el
+++ b/posframe.el
@@ -709,8 +709,10 @@ ACCEPT-FOCUS."
                    (frame-live-p posframe--frame)
                    ;; For speed reason, posframe will reuse
                    ;; existing frame at possible, but when
-                   ;; user change args, recreating frame
-                   ;; is needed.
+                   ;; user changes args or terminal,
+                   ;; recreating the frame is needed.
+                   (eq (frame-terminal posframe--frame)
+                       (frame-terminal parent-frame))
                    (equal posframe--last-args args))
         (posframe-delete-frame buffer)
         (setq-local posframe--last-args args)


### PR DESCRIPTION
The `(eq ...)` form was proposed by an LLM but that is probably not copyrightable; the comment change, commit message and this report are all written by me after the LLM root-caused the problem.  (This is relevant because this is a GNU ELPA package.)

If you have Emacs frames connected to a single daemon but on different X displays, posframe can fail; here is the case someone at work ran into with posframe as invoked by company-mode:

    Company: An error occurred in post-command
    Company: frontend jane-completion-aide-company-frontend error "Invalid ‘parent-frame’ frame parameter" on command post-command

This happens because posframe tries to reuse the posframe created on the first display on the second.  Specifically, when `posframe--create-posframe` reaches `(set-frame-parameter posframe--frame 'parent-frame parent-frame)` it tries to reparent the frame to a parent on another terminal, which Emacs rejects.

The simple fix is to skip reusing the a frame on a different terminal.  Thanks.